### PR TITLE
Feat/add cli options for styles and clothings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ cowcowsecrets.py
 ssl.key
 ssl.csr
 *~
+
+# Default output dir
+out/


### PR DESCRIPTION
New parameters are introduced to the CLI:

--clothing: allows selecting other items of clothing to customize (two
new pieces of clothing are available now!).
--style: allows setting the style (color-wise) more easily.

The new parameters follow the same pattern:
- One parameter allows to set the value
- A companion --list-* parameter lists all possible values and then
exits.

Since I picked the extra clothing items, I went for a basketball tank top because that's what I'm likely to actually wear.

Then I felt terrible about adding an item without pockets given the significance of "a dress with pockets" (:sob: ) ... So I added a second example item that is a pure pocket (and that I am coincidentally also likely to actually order).

I took the liberty to run "black" on the source code and remove a couple of unused imports.

Thanks for this project, it's really cool :+1: 